### PR TITLE
Fix compile error from nim cpp tests/test.nim

### DIFF
--- a/src/imgui/private/ncimgui.h
+++ b/src/imgui/private/ncimgui.h
@@ -1,4 +1,5 @@
 #include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
 #include "cimgui.h"
 
 // Should open an issue in cimgui about this...


### PR DESCRIPTION
I tried to build `nimgl\examples\timgui.nim` with `nim cpp --path:..\src timgui.nim`.
But I got following compile errors from backend cpp compiler(gcc).
It seems `nimgl/src/nimgl/private/cimgui/cimgui.h` uses types defined in `imgui/imgui_internal.h` but it is not included.
As actual compile error was very long, I wrote first few lines.

```
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1737:18: error: 'ImGuiSettingsHandler' was not declared in this scope
 1737 | typedef ImVector<ImGuiSettingsHandler> ImVector_ImGuiSettingsHandler;
      |                  ^~~~~~~~~~~~~~~~~~~~
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1737:38: error: template argument 1 is invalid
 1737 | typedef ImVector<ImGuiSettingsHandler> ImVector_ImGuiSettingsHandler;
      |                                      ^
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1739:18: error: 'ImGuiGroupData' was not declared in this scope
 1739 | typedef ImVector<ImGuiGroupData> ImVector_ImGuiGroupData;
      |                  ^~~~~~~~~~~~~~
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1739:32: error: template argument 1 is invalid
 1739 | typedef ImVector<ImGuiGroupData> ImVector_ImGuiGroupData;
      |                                ^
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1741:18: error: 'ImGuiWindow' was not declared in this scope
 1741 | typedef ImVector<ImGuiWindow*> ImVector_ImGuiWindowPtr;
      |                  ^~~~~~~~~~~
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1741:30: error: template argument 1 is invalid
 1741 | typedef ImVector<ImGuiWindow*> ImVector_ImGuiWindowPtr;
      |                              ^
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1742:18: error: 'ImGuiColumnData' was not declared in this scope
 1742 | typedef ImVector<ImGuiColumnData> ImVector_ImGuiColumnData;
      |                  ^~~~~~~~~~~~~~~
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1742:33: error: template argument 1 is invalid
 1742 | typedef ImVector<ImGuiColumnData> ImVector_ImGuiColumnData;
      |                                 ^
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1743:18: error: 'ImGuiColumns' was not declared in this scope; did you mean 'ImGuiCol_Tab'?
 1743 | typedef ImVector<ImGuiColumns> ImVector_ImGuiColumns;
      |                  ^~~~~~~~~~~~
      |                  ImGuiCol_Tab
f:/temp/nimgl/src/nimgl/private/cimgui/cimgui.h:1743:30: error: template argument 1 is invalid
 1743 | typedef ImVector<ImGuiColumns> ImVector_ImGuiColumns;
```