### PR TITLE
Fix compile error when igSetNextWindowPos is called

### DIFF
--- a/src/imgui.nim
+++ b/src/imgui.nim
@@ -198,6 +198,7 @@ type
     NoArrowButton = 32
     NoPreview = 64
   ImGuiCond* {.pure, size: int32.sizeof.} = enum
+    Default = 0
     Always = 1
     Once = 2
     FirstUseEver = 4


### PR DESCRIPTION
When I called `igSetNextWindowPos`, I got compile error `nimgl\src\nimgl\imgui.nim(2265, 58) Error: conversion from int literal(0) to ImGuiCond is invalid`.
I got that error because `ImGuiCond` doesn't contain a constant with value 0.
`enum ImGuiCond_` in `imgui.h` also doesn't contain such constant but the value 0 is used as default value of `ImGuiCond` type arguments.
I added a constant `Default = 0` to `ImGuiCond` to solve the compile error.
