### PR TITLE
Fixed `UncheckedArray`

### DIFF
--- a/src/imgui.nim
+++ b/src/imgui.nim
@@ -800,7 +800,7 @@ type
     cmdListsCount* {.importc: "CmdListsCount".}: int32
     totalIdxCount* {.importc: "TotalIdxCount".}: int32
     totalVtxCount* {.importc: "TotalVtxCount".}: int32
-    cmdLists* {.importc: "CmdLists".}: UncheckedArray[ptr ImDrawList]
+    cmdLists* {.importc: "CmdLists".}: ptr UncheckedArray[ptr ImDrawList]
     displayPos* {.importc: "DisplayPos".}: ImVec2
     displaySize* {.importc: "DisplaySize".}: ImVec2
     framebufferScale* {.importc: "FramebufferScale".}: ImVec2

--- a/src/imgui.nim
+++ b/src/imgui.nim
@@ -746,7 +746,7 @@ type
   ImVector*[T] = object # Should I importc a generic?
     size* {.importc: "Size".}: int32
     capacity* {.importc: "Capacity".}: int32
-    data* {.importc: "Data".}: UncheckedArray[T]
+    data* {.importc: "Data".}: ptr UncheckedArray[T]
   ImGuiStyleModBackup* {.union.} = object
     backup_int* {.importc: "BackupInt".}: int32 # Breaking naming convetion to denote "low level"
     backup_float* {.importc: "BackupFloat".}: float32


### PR DESCRIPTION
Edited `imgui.nim`:
- `ImVector.data: UncheckedArray[T]` -> `ptr UncheckedArray[T]`
- `ImDrawList.cmdLists: UncheckedArray[ptr ImDrawList]` -> `ptr UncheckedArray[ptr ImDrawList]`

## Usage Example
```nim
import nimgl/imgui, nimgl/imgui/[impl_opengl, impl_glfw]
import nimgl/[opengl, glfw]

proc main() =
  doAssert glfwInit()

  glfwWindowHint(GLFWContextVersionMajor, 3)
  glfwWindowHint(GLFWContextVersionMinor, 3)
  glfwWindowHint(GLFWOpenglForwardCompat, GLFW_TRUE)
  glfwWindowHint(GLFWOpenglProfile, GLFW_OPENGL_CORE_PROFILE)
  glfwWindowHint(GLFWResizable, GLFW_FALSE)

  var w: GLFWWindow = glfwCreateWindow(1280, 720)
  if w == nil:
    quit(-1)

  w.makeContextCurrent()

  doAssert glInit()

  let context = igCreateContext()
  #let io = igGetIO()

  doAssert igGlfwInitForOpenGL(w, true)
  doAssert igOpenGL3Init()

  igStyleColorsCherry()

  while not w.windowShouldClose:
    glfwPollEvents()

    igOpenGL3NewFrame()
    igGlfwNewFrame()
    igNewFrame()

    # Simple window
    igBegin("Hello, world!")

    var filter: ImGuiTextFilter # Before it complained Error: invalid type: 'UncheckedArray[ImGuiTextRange]' in this context: 'ImGuiTextFilter' for var
    filter.addr.draw()
    
    for line in ["aaa1.c", "bbb1.c", "ccc1.c", "aaa2.cpp", "bbb2.cpp", "ccc2.cpp", "abc.h", "hello, world"]:
      if filter.addr.passFilter(line):
        igBulletText("%s", line)

    igEnd()
    # End simple window

    igRender()

    glClearColor(0.45f, 0.55f, 0.60f, 1.00f)
    glClear(GL_COLOR_BUFFER_BIT)

    igOpenGL3RenderDrawData(igGetDrawData())

    w.swapBuffers()

  igOpenGL3Shutdown()
  igGlfwShutdown()
  context.igDestroyContext()

  w.destroyWindow()
  glfwTerminate()

main()
```
