### PR TITLE
Use static library when necessary

### DIFF
--- a/imgui.nimble
+++ b/imgui.nimble
@@ -11,6 +11,9 @@ skipDirs    = @["tests"]
 
 requires "nim >= 1.0.0" # 1.0.0 promises that it will have backward compatibility
 
+before install:
+  exec("nim c -r makecimgui.nim")
+
 task gen, "Generate bindings from source":
   exec("nim c -r tools/generator.nim")
 
@@ -23,3 +26,4 @@ task ci, "Create window with imgui null demo":
   requires "nimgl@#1.0" # Please https://github.com/nim-lang/nimble/issues/482
   exec("nim c -r tests/tnull.nim") # requires cimgui.dll
   exec("nim cpp -r tests/tnull.nim")
+

--- a/makecimgui.nim
+++ b/makecimgui.nim
@@ -1,13 +1,19 @@
 import std/[os, strutils]
-import system
+#import system
 # import system/io
 
 var (dir, name, ext) = splitFile(currentSourcePath())
-dir = dir.joinPath("cimgui")
-echo dir
-cd(dir)
+dir = dir.joinPath("./src/imgui/private/cimgui")
+#echo dir
+setCurrentDir(dir)
+
+
+proc exec(s: string) =
+    assert 0 == os.execShellCmd(s)
+
 if fileExists("libcimgui.a"):
-  echo("Warning: libcimgui.a already built. Rebuilding")
+  echo("Warning: libcimgui.a already built. Skipping.")
+  quit()
 
 if "-fno-threadsafe-statics" notin open("Makefile").readAll():
   exec("git apply ../0001-Remove-threadsafe.patch")

--- a/src/imgui.nim
+++ b/src/imgui.nim
@@ -32,13 +32,20 @@ when defined(linux):
   {.passL: "-Xlinker -rpath .".}
 
 when defined(c):
-  {.passC: "-DCIMGUI_DEFINE_ENUMS_AND_STRUCTS".}
-  {.pragma: imgui_header, header: "cimgui.h".}
-  when not defined(cimguiDLL):
-    {.fatal: "No build script for C yet".}
-when defined(cimguiDLL):
-  const cimguiDLL {.strdefine.}: string = ""
-  const imgui_dll* = cimguiDLL
+  {.pragma: imgui_header, header: currentSourceDir() & "/imgui/private/ncimgui_c.h".}
+  when defined(cimguiDLL):
+    {.fatal: "not supported yet".}
+    when defined(windows):
+      const cimguiDLL {.strdefine.}: string = "cimgui.dll"
+    elif defined(macosx):
+      const cimguiDLL {.strdefine.}: string = "cimgui.dylib"
+    else:
+      const cimguiDLL {.strdefine.}: string = "cimgui.so"
+    const imgui_dll* = cimguiDLL
+  else:
+    # TODO: 
+    # run "makecimgui.nim" before install
+    {.passL: cimgui_dir & "/libcimgui.a".}
 
 when defined(cpp):
   {.compile: cimgui_dir & "/cimgui.cpp",
@@ -1927,8 +1934,11 @@ type
 
 # Procs
 {.push warning[HoleEnumConv]: off.}
-when not defined(cpp) or defined(cimguiDLL):
-  {.push dynlib: imgui_dll, cdecl, discardable.}
+when not defined(cpp):
+  when defined(cimguiDLL):
+    {.push dynlib: imgui_dll, cdecl, discardable.}
+  else:
+    {.push nodecl, discardable.}
 else:
   {.push nodecl, discardable.}
 

--- a/src/imgui.nim
+++ b/src/imgui.nim
@@ -25,26 +25,28 @@ proc currentSourceDir(): string {.compileTime.} =
   result = currentSourcePath().replace("\\", "/")
   result = result[0 ..< result.rfind("/")]
 
-{.passC: "-I" & currentSourceDir() & "/imgui/private/cimgui" & " -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS=1".}
+const cimgui_dir = currentSourceDir() & "/imgui/private/cimgui"
+
+{.passC: "-I" & cimgui_dir & " -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS=1".}
 when defined(linux):
   {.passL: "-Xlinker -rpath .".}
 
-when not defined(cpp) or defined(cimguiDLL):
-  when defined(windows):
-    const imgui_dll* = "cimgui.dll"
-  elif defined(macosx):
-    const imgui_dll* = "cimgui.dylib"
-  else:
-    const imgui_dll* = "cimgui.so"
+when defined(c):
   {.passC: "-DCIMGUI_DEFINE_ENUMS_AND_STRUCTS".}
   {.pragma: imgui_header, header: "cimgui.h".}
-else:
-  {.compile: "imgui/private/cimgui/cimgui.cpp",
-    compile: "imgui/private/cimgui/imgui/imgui.cpp",
-    compile: "imgui/private/cimgui/imgui/imgui_draw.cpp",
-    compile: "imgui/private/cimgui/imgui/imgui_tables.cpp",
-    compile: "imgui/private/cimgui/imgui/imgui_widgets.cpp",
-    compile: "imgui/private/cimgui/imgui/imgui_demo.cpp".}
+  when not defined(cimguiDLL):
+    {.fatal: "No build script for C yet".}
+when defined(cimguiDLL):
+  const cimguiDLL {.strdefine.}: string = ""
+  const imgui_dll* = cimguiDLL
+
+when defined(cpp):
+  {.compile: cimgui_dir & "/cimgui.cpp",
+    compile: cimgui_dir & "/imgui/imgui.cpp",
+    compile: cimgui_dir & "/imgui/imgui_draw.cpp",
+    compile: cimgui_dir & "/imgui/imgui_tables.cpp",
+    compile: cimgui_dir & "/imgui/imgui_widgets.cpp",
+    compile: cimgui_dir & "/imgui/imgui_demo.cpp".}
   {.pragma: imgui_header, header: currentSourceDir() & "/imgui/private/ncimgui.h".}
 
 # Enums

--- a/src/imgui/private/0001-Remove-threadsafe.patch
+++ b/src/imgui/private/0001-Remove-threadsafe.patch
@@ -1,0 +1,22 @@
+Subject: [PATCH] Remove threadsafe
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d5462fc..90cc096 100644
+--- a/Makefile
++++ b/Makefile
+@@ -9,7 +9,7 @@ OBJS += ./imgui/imgui_demo.o
+ OBJS += ./imgui/imgui_tables.o
+ OBJS += ./imgui/imgui_widgets.o
+ 
+-CXXFLAGS=-O2 -fno-exceptions -fno-rtti
++CXXFLAGS=-O2 -fno-exceptions -fno-rtti -fno-threadsafe-statics
+ 
+ UNAME_S := $(shell uname -s)
+ 
+-- 
+2.36.1
+

--- a/src/imgui/private/makecimgui.nim
+++ b/src/imgui/private/makecimgui.nim
@@ -1,0 +1,16 @@
+import std/[os, strutils]
+import system
+# import system/io
+
+var (dir, name, ext) = splitFile(currentSourcePath())
+dir = dir.joinPath("cimgui")
+echo dir
+cd(dir)
+if fileExists("libcimgui.a"):
+  echo("Warning: libcimgui.a already built. Rebuilding")
+
+if "-fno-threadsafe-statics" notin open("Makefile").readAll():
+  exec("git apply ../0001-Remove-threadsafe.patch")
+
+exec("make clean")
+exec("make static")

--- a/src/imgui/private/ncimgui_c.h
+++ b/src/imgui/private/ncimgui_c.h
@@ -1,0 +1,2 @@
+#define CIMGUI_DEFINE_ENUMS_AND_STRUCTS
+#include "cimgui.h"


### PR DESCRIPTION
I added a Nim script to patch cimgui and build `libcimgui.a`.

However, I don't know how to run this script on build. (I did it manually and it worked fine)